### PR TITLE
Change waitASec to wait

### DIFF
--- a/examples/tui/main.go
+++ b/examples/tui/main.go
@@ -39,9 +39,9 @@ func animate() tea.Cmd {
 	})
 }
 
-func waitASec(ms int) tea.Cmd {
+func wait(d time.Duration) tea.Cmd {
 	return func() tea.Msg {
-		time.Sleep(time.Millisecond * time.Duration(ms))
+		time.Sleep(d)
 		return nil
 	}
 }
@@ -53,7 +53,7 @@ type model struct {
 }
 
 func (_ model) Init() tea.Cmd {
-	return tea.Sequentially(waitASec(500), animate())
+	return tea.Sequentially(wait(time.Second/2), animate())
 }
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -70,7 +70,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Quit when we're basically at the target position.
 		if math.Abs(m.x-targetX) < 0.01 {
-			return m, tea.Sequentially(waitASec(750), tea.Quit)
+			return m, tea.Sequentially(wait(3/4*time.Second), tea.Quit)
 		}
 
 		// Request next frame


### PR DESCRIPTION
This is a _tiny_ refactor that doesn't change any functionality.

While playing around with this library, I saw that `waitASec` sometimes sleeps
for `500ms` and `750ms`, for me this makes sense to call it `wait` instead of
`waitASec` and accept a `time.Duration` instead of an `int`.

Not a big deal either way though! Feel free to merge or close this PR.

Great work on this library! :D
