### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For details, see the [examples][examples] and the [docs][docs].
 * **Time Delta:** the time step to operate on. Game engines typically provide
   a way to determine the time delta, however if that's not available you can
   simply set the framerate with the included `FPS(int)` utility function. Make
-  the framerate you set here matches your actual framerate.
+  sure the framerate you set here matches your actual framerate.
 * **Angular Velocity:** this translates roughly to the speed. Higher values are
   faster.
 * **Damping Ratio:** the springiness of the animation, generally between `0`

--- a/spring.go
+++ b/spring.go
@@ -118,7 +118,7 @@ type Spring struct {
 // oscillation, or lack thereof. There are three categories of damping ratios:
 //
 // Damping ratio > 1: over-damped.
-// Damping ratio = 1: critlcally-damped.
+// Damping ratio = 1: critically-damped.
 // Damping ratio < 1: under-damped.
 //
 // An over-damped spring will never oscillate, but reaches equilibrium at


### PR DESCRIPTION
The README.md sentence sounds wrong in my head — I think it makes more sense with "sure" included. And just a minor fix in spring.go.