### PR TITLE
docs: fix Spring comment typo

### DIFF
--- a/spring.go
+++ b/spring.go
@@ -87,7 +87,7 @@ var epsilon = math.Nextafter(1, 2) - 1
 //
 // To use a Spring call New with the time delta (that's animation frame
 // length), frequency, and damping parameters, cache the result, then call
-// Update to update position and velocity values for each spring that neeeds
+// Update to update position and velocity values for each spring that needs
 // updating.
 //
 // Example:


### PR DESCRIPTION
## Summary
- fix a typo in the cached Spring comment

## Related issue
- N/A (trivial comment typo fix)

## Guideline alignment
- CONTRIBUTING: none found in the repo root or .github on master
- PR template: none found in the repo root or .github on master

## Validation
- Not run (comment-only change)
