### PR TITLE
test(spring): add spring tests and fix typos

### DIFF
--- a/harmonica.go
+++ b/harmonica.go
@@ -1,32 +1,32 @@
 // Package harmonica is a set of physics-based animation tools for 2D and 3D
-// applications. There's a spring animation simulator for for smooth, realistic
+// applications. There's a spring animation simulator for smooth, realistic
 // motion and a projectile simulator well suited for projectiles and particles.
 //
 // Example spring usage:
 //
-//     // Run once to initialize.
-//     spring := NewSpring(FPS(60), 6.0, 0.2)
+//	// Run once to initialize.
+//	spring := NewSpring(FPS(60), 6.0, 0.2)
 //
-//     // Update on every frame.
-//     pos := 0.0
-//     velocity := 0.0
-//     targetPos := 100.0
-//     someUpdateLoop(func() {
-//         pos, velocity = spring.Update(pos, velocity, targetPos)
-//     })
+//	// Update on every frame.
+//	pos := 0.0
+//	velocity := 0.0
+//	targetPos := 100.0
+//	someUpdateLoop(func() {
+//	    pos, velocity = spring.Update(pos, velocity, targetPos)
+//	})
 //
 // Example projectile usage:
 //
-//    // Run once to initialize.
-//    projectile := NewProjectile(
-//        FPS(60),
-//        Point{6.0, 100.0, 0.0},
-//        Vector{2.0, 0.0, 0.0},
-//        Vector{2.0, -9.81, 0.0},
-//    )
+//	// Run once to initialize.
+//	projectile := NewProjectile(
+//	    FPS(60),
+//	    Point{6.0, 100.0, 0.0},
+//	    Vector{2.0, 0.0, 0.0},
+//	    Vector{2.0, -9.81, 0.0},
+//	)
 //
-//    // Update on every frame.
-//    someUpdateLoop(func() {
-//        pos := projectile.Update()
-//    })
+//	// Update on every frame.
+//	someUpdateLoop(func() {
+//	    pos := projectile.Update()
+//	})
 package harmonica

--- a/projectile.go
+++ b/projectile.go
@@ -46,10 +46,10 @@ type Vector struct {
 // Gravity is a utility vector that represents gravity in 2D and 3D contexts,
 // assuming that your coordinate plane looks like in 2D or 3D:
 //
-//   y             y ±z
-//   │             │ /
-//   │             │/
-//   └───── ±x     └───── ±x
+//	y             y ±z
+//	│             │ /
+//	│             │/
+//	└───── ±x     └───── ±x
 //
 // (i.e. origin is located in the bottom-left corner)
 var Gravity = Vector{0, -9.81, 0}
@@ -61,11 +61,11 @@ var TerminalGravity = Vector{0, 9.81, 0}
 // NewProjectile creates a new projectile. It accepts a frame rate and initial
 // values for position, velocity, and acceleration. It returns a new
 // projectile.
-func NewProjectile(deltaTime float64, initialPosition Point, initialVelocity, initalAcceleration Vector) *Projectile {
+func NewProjectile(deltaTime float64, initialPosition Point, initialVelocity, initialAcceleration Vector) *Projectile {
 	return &Projectile{
 		pos:       initialPosition,
 		vel:       initialVelocity,
-		acc:       initalAcceleration,
+		acc:       initialAcceleration,
 		deltaTime: deltaTime,
 	}
 }

--- a/projectile_test.go
+++ b/projectile_test.go
@@ -30,7 +30,8 @@ func TestNew(t *testing.T) {
 const equalityThreshold = 1e-2
 
 // floating point comparison function that tests for an equality under the:
-//    equalityThreshold
+//
+//	equalityThreshold
 func equal(a, b float64) bool {
 	return math.Abs(a-b) <= equalityThreshold
 }

--- a/spring.go
+++ b/spring.go
@@ -62,8 +62,7 @@ import (
 //
 // Example:
 //
-//     spring := NewSpring(FPS(60), 5.0, 0.2)
-//
+//	spring := NewSpring(FPS(60), 5.0, 0.2)
 func FPS(n int) float64 {
 	return (time.Second / time.Duration(n)).Seconds()
 }
@@ -71,11 +70,11 @@ func FPS(n int) float64 {
 // In calculus ε is, in vague terms, an arbitrarily small positive number. In
 // the original C++ source ε is represented as such:
 //
-//     const float epsilon = 0.0001
+//	   const float epsilon = 0.0001
 //
-//  Some Go programmers use:
+//	Some Go programmers use:
 //
-//     const epsilon float64 = 0.00000001
+//	   const epsilon float64 = 0.00000001
 //
 // We can, however, calculate the machine’s epsilon value, with the drawback
 // that it must be a variable versus a constant.
@@ -87,20 +86,19 @@ var epsilon = math.Nextafter(1, 2) - 1
 //
 // To use a Spring call New with the time delta (that's animation frame
 // length), frequency, and damping parameters, cache the result, then call
-// Update to update position and velocity values for each spring that neeeds
+// Update to update position and velocity values for each spring that needs
 // updating.
 //
 // Example:
 //
-//     // First precompute spring coefficients based on your settings:
-//     var x, xVel, y, yVel float64
-//     deltaTime := FPS(60)
-//     s := NewSpring(deltaTime, 5.0, 0.2)
+//	// First precompute spring coefficients based on your settings:
+//	var x, xVel, y, yVel float64
+//	deltaTime := FPS(60)
+//	s := NewSpring(deltaTime, 5.0, 0.2)
 //
-//     // Then, in your update loop:
-//     x, xVel = s.Update(x, xVel, 10) // update the X position
-//     y, yVel = s.Update(y, yVel, 20) // update the Y position
-//
+//	// Then, in your update loop:
+//	x, xVel = s.Update(x, xVel, 10) // update the X position
+//	y, yVel = s.Update(y, yVel, 20) // update the Y position
 type Spring struct {
 	posPosCoef, posVelCoef float64
 	velPosCoef, velVelCoef float64

--- a/spring_test.go
+++ b/spring_test.go
@@ -1,0 +1,135 @@
+package harmonica_test
+
+import (
+	"math"
+	"testing"
+
+	. "github.com/charmbracelet/harmonica"
+)
+
+func TestFPS(t *testing.T) {
+	delta := FPS(60)
+	expected := 1.0 / 60.0
+	if math.Abs(delta-expected) > 1e-9 {
+		t.Fatalf("FPS(60) = %f, want %f", delta, expected)
+	}
+
+	delta = FPS(30)
+	expected = 1.0 / 30.0
+	if math.Abs(delta-expected) > 1e-9 {
+		t.Fatalf("FPS(30) = %f, want %f", delta, expected)
+	}
+}
+
+func TestSpringCriticallyDamped(t *testing.T) {
+	// Damping ratio = 1.0: critically damped, should converge without oscillation.
+	s := NewSpring(FPS(60), 6.0, 1.0)
+
+	pos := 0.0
+	vel := 0.0
+	target := 100.0
+
+	for i := 0; i < 600; i++ { // 10 seconds at 60fps
+		pos, vel = s.Update(pos, vel, target)
+	}
+
+	if math.Abs(pos-target) > 0.01 {
+		t.Fatalf("critically damped spring did not converge: pos=%f, target=%f", pos, target)
+	}
+	if math.Abs(vel) > 0.01 {
+		t.Fatalf("critically damped spring still has velocity: %f", vel)
+	}
+}
+
+func TestSpringUnderDamped(t *testing.T) {
+	// Damping ratio < 1.0: under-damped, should oscillate then converge.
+	s := NewSpring(FPS(60), 6.0, 0.2)
+
+	pos := 0.0
+	vel := 0.0
+	target := 100.0
+
+	// Track whether we overshoot (characteristic of under-damped).
+	overshot := false
+	for i := 0; i < 1200; i++ { // 20 seconds
+		pos, vel = s.Update(pos, vel, target)
+		if pos > target+0.1 {
+			overshot = true
+		}
+	}
+
+	if !overshot {
+		t.Fatal("under-damped spring should overshoot target")
+	}
+
+	if math.Abs(pos-target) > 0.01 {
+		t.Fatalf("under-damped spring did not converge: pos=%f, target=%f", pos, target)
+	}
+}
+
+func TestSpringOverDamped(t *testing.T) {
+	// Damping ratio > 1.0: over-damped, should converge slowly without oscillation.
+	s := NewSpring(FPS(60), 6.0, 2.0)
+
+	pos := 0.0
+	vel := 0.0
+	target := 100.0
+
+	for i := 0; i < 600; i++ {
+		prevPos := pos
+		pos, vel = s.Update(pos, vel, target)
+		// Over-damped should monotonically approach target (no overshooting).
+		if pos > target+0.001 {
+			t.Fatalf("over-damped spring overshot at frame %d: pos=%f", i, pos)
+		}
+		// Should always move toward target (or stay).
+		if i > 0 && pos < prevPos-0.001 {
+			t.Fatalf("over-damped spring moved away from target at frame %d", i)
+		}
+	}
+
+	if math.Abs(pos-target) > 0.01 {
+		t.Fatalf("over-damped spring did not converge: pos=%f, target=%f", pos, target)
+	}
+}
+
+func TestSpringZeroFrequency(t *testing.T) {
+	// Zero angular frequency: spring should not move.
+	s := NewSpring(FPS(60), 0.0, 0.5)
+
+	pos := 50.0
+	vel := 10.0
+	target := 100.0
+
+	newPos, newVel := s.Update(pos, vel, target)
+
+	// With zero frequency, position should stay the same relative to equilibrium,
+	// and velocity should be preserved (identity coefficients).
+	if math.Abs(newPos-pos) > 1e-9 {
+		t.Fatalf("zero-frequency spring moved: pos=%f, expected=%f", newPos, pos)
+	}
+	if math.Abs(newVel-vel) > 1e-9 {
+		t.Fatalf("zero-frequency spring changed velocity: vel=%f, expected=%f", newVel, vel)
+	}
+}
+
+func TestSpringMultipleTargetChanges(t *testing.T) {
+	s := NewSpring(FPS(60), 6.0, 0.8)
+
+	pos := 0.0
+	vel := 0.0
+
+	// Move toward 100.
+	for i := 0; i < 300; i++ {
+		pos, vel = s.Update(pos, vel, 100.0)
+	}
+
+	// Change target to -50.
+	for i := 0; i < 600; i++ {
+		pos, vel = s.Update(pos, vel, -50.0)
+	}
+
+	if math.Abs(pos-(-50.0)) > 0.1 {
+		t.Fatalf("spring did not converge to new target: pos=%f, target=-50", pos)
+	}
+}


### PR DESCRIPTION
## Changes

- **Add spring tests** (`spring_test.go`): comprehensive coverage for all three damping regimes (critically-damped, under-damped, over-damped), zero-frequency edge case, FPS helper, and multi-target-change behavior
- **Fix typos**: `"for for"` → `"for"` in package doc, `"neeeds"` → `"needs"` in Spring doc comment
- **Fix parameter name**: `initalAcceleration` → `initialAcceleration` in `NewProjectile`

All existing tests continue to pass.