### PR TITLE
docs(examples): document OpenGL system dependencies

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,28 @@
+# Examples
+
+Run examples from this directory (`examples/`), not the repository root.
+
+## Terminal UI
+
+```bash
+go run ./spring/tui
+go run ./particle
+```
+
+## OpenGL (`spring/opengl`)
+
+This demo uses CGO and links against GLFW/OpenGL via `pkg-config`. Install system libraries first:
+
+| OS | Packages |
+|----|----------|
+| macOS | `brew install glfw pkg-config` |
+| Debian/Ubuntu | `sudo apt install libglfw3-dev libgl1-mesa-dev pkg-config` |
+| Fedora | `sudo dnf install glfw-devel mesa-libGL-devel pkg-config` |
+
+Then:
+
+```bash
+go run ./spring/opengl
+```
+
+If `pkg-config` cannot find `gl`, the build fails before Go compiles the example — that usually means the packages above are missing or `PKG_CONFIG_PATH` is unset.


### PR DESCRIPTION
## Summary

Adds `examples/README.md` with run instructions for the TUI demos and documents the GLFW/OpenGL/pkg-config packages required to build `spring/opengl`.

## Context

Users hitting `Package gl was not found` when running the OpenGL example need system libraries installed first; the README makes that explicit.

Fixes #13