### PR TITLE
docs: fix two godoc typos

### DIFF
--- a/harmonica.go
+++ b/harmonica.go
@@ -1,5 +1,5 @@
 // Package harmonica is a set of physics-based animation tools for 2D and 3D
-// applications. There's a spring animation simulator for for smooth, realistic
+// applications. There's a spring animation simulator for smooth, realistic
 // motion and a projectile simulator well suited for projectiles and particles.
 //
 // Example spring usage:

--- a/projectile.go
+++ b/projectile.go
@@ -61,11 +61,11 @@ var TerminalGravity = Vector{0, 9.81, 0}
 // NewProjectile creates a new projectile. It accepts a frame rate and initial
 // values for position, velocity, and acceleration. It returns a new
 // projectile.
-func NewProjectile(deltaTime float64, initialPosition Point, initialVelocity, initalAcceleration Vector) *Projectile {
+func NewProjectile(deltaTime float64, initialPosition Point, initialVelocity, initialAcceleration Vector) *Projectile {
 	return &Projectile{
 		pos:       initialPosition,
 		vel:       initialVelocity,
-		acc:       initalAcceleration,
+		acc:       initialAcceleration,
 		deltaTime: deltaTime,
 	}
 }


### PR DESCRIPTION
Two small godoc-visible typos:

- Package doc reads "spring animation simulator for for smooth, realistic motion" with a doubled "for".
- `NewProjectile`'s third Vector parameter is `initalAcceleration` (missing 'i'), which renders in the godoc signature alongside the correctly spelled `initialPosition` and `initialVelocity`.